### PR TITLE
Allow non-https token revocation endpoint

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1784,6 +1784,26 @@ fn test_token_revocation_with_non_https_url() {
 }
 
 #[test]
+fn test_token_revocation_unchecked() {
+    let client = new_client();
+
+    client
+        .set_revocation_uri(RevocationUrl::new("https://revocation/url".to_string()).unwrap())
+        .revoke_token_with_unchecked_url(AccessToken::new("access_token_123".to_string()).into())
+        .unwrap();
+}
+
+#[test]
+fn test_token_revocation_unchecked_with_insecure_url() {
+    let client = new_client();
+
+    client
+        .set_revocation_uri(RevocationUrl::new("http://revocation/url".to_string()).unwrap())
+        .revoke_token_with_unchecked_url(AccessToken::new("access_token_123".to_string()).into())
+        .unwrap();
+}
+
+#[test]
 fn test_token_revocation_with_unsupported_token_type() {
     let client = new_client()
         .set_revocation_uri(RevocationUrl::new("https://revocation/url".to_string()).unwrap());


### PR DESCRIPTION
HTTPS is still enforced for the `client.revoke_token()` method in compliance with RFC 7009, but may now be bypassed by calling `client.revoke_token_with_unchecked_url()`.

When developing my appliation locally, I run a local copy of the oauth server without https. It was surprising to find the https checking on the revocation request, since it isn't enforced for auth or token exchange requests.